### PR TITLE
Remove mention of `charset="UTF-8"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Simply load the module after loading highlight.js. You'll use the minified versi
 
 ```html
 <script type="text/javascript" src="/path/to/highlight.min.js"></script>
-<script type="text/javascript" charset="UTF-8" src="/path/to/highlightjs-qsharp/dist/qsharp.min.js"></script>
+<script type="text/javascript" src="/path/to/highlightjs-qsharp/dist/qsharp.min.js"></script>
 <script type="text/javascript"> hljs.initHighlightingOnLoad(); </script>
 ```
 


### PR DESCRIPTION
When building with our modern build system the UTF-8 flag should no longer be necessary.  

If your `dist` contains UTF-8 characters you may want to rebuild it with the latest version of Highlight.js.